### PR TITLE
Do not force keys to be strings

### DIFF
--- a/lib/avl_tree.rb
+++ b/lib/avl_tree.rb
@@ -355,17 +355,17 @@ class AVLTree
   end
 
   def []=(key, value)
-    @root = @root.insert(key.to_s, value)
+    @root = @root.insert(key, value)
   end
   alias insert []=
 
   def key?(key)
-    @root.retrieve(key.to_s) != Node::UNDEFINED
+    @root.retrieve(key) != Node::UNDEFINED
   end
   alias has_key? key?
 
   def [](key)
-    value = @root.retrieve(key.to_s)
+    value = @root.retrieve(key)
     if value == Node::UNDEFINED
       default_value
     else
@@ -374,7 +374,7 @@ class AVLTree
   end
 
   def delete(key)
-    deleted, @root = @root.delete(key.to_s)
+    deleted, @root = @root.delete(key)
     deleted.value
   end
 

--- a/lib/red_black_tree.rb
+++ b/lib/red_black_tree.rb
@@ -496,19 +496,19 @@ class RedBlackTree
   end
 
   def []=(key, value)
-    @root = @root.insert(key.to_s, value)
+    @root = @root.insert(key, value)
     @root.set_root
     @root.check_height if $DEBUG
   end
   alias insert []=
 
   def key?(key)
-    @root.retrieve(key.to_s) != Node::UNDEFINED
+    @root.retrieve(key) != Node::UNDEFINED
   end
   alias has_key? key?
 
   def [](key)
-    value = @root.retrieve(key.to_s)
+    value = @root.retrieve(key)
     if value == Node::UNDEFINED
       default_value
     else
@@ -517,7 +517,7 @@ class RedBlackTree
   end
 
   def delete(key)
-    deleted, @root, rebalance = @root.delete(key.to_s)
+    deleted, @root, rebalance = @root.delete(key)
     unless empty?
       @root.set_root
       @root.check_height if $DEBUG

--- a/test/test_avl_tree.rb
+++ b/test/test_avl_tree.rb
@@ -372,9 +372,9 @@ class TestAVLTree < Test::Unit::TestCase
 
   def test_to_s
     h = AVLTree.new
-    h[:abc] = 1
-    assert_equal 1, h["abc"]
-    assert_equal 1, h[:abc]
+    h[5] = 1
+    assert_equal 1, h[5]
+    assert_nil h["5"]
   end
 
   def test_key?
@@ -422,6 +422,14 @@ class TestAVLTree < Test::Unit::TestCase
     h.clear
     assert_equal 0, h.size
     assert h.to_hash.empty?
+  end
+
+  def test_non_string_keys
+    h = AVLTree.new
+    h[1.3] = 'a'
+    h[4.3] = 'b'
+
+    assert_equal [1.3, 'a' ], h.first
   end
 
   if RUBY_VERSION >= '1.9.0'

--- a/test/test_red_black_tree.rb
+++ b/test/test_red_black_tree.rb
@@ -522,9 +522,9 @@ class TestRedBlackTree < Test::Unit::TestCase
 
   def test_to_s
     h = RedBlackTree.new
-    h[:abc] = 1
-    assert_equal 1, h["abc"]
-    assert_equal 1, h[:abc]
+    h[5] = 1
+    assert_equal 1, h[5]
+    assert_nil h["5"]
   end
 
   def test_key?
@@ -572,6 +572,14 @@ class TestRedBlackTree < Test::Unit::TestCase
     h.clear
     assert_equal 0, h.size
     assert h.to_hash.empty?
+  end
+
+  def test_non_string_keys
+    h = RedBlackTree.new
+    h[1.3] = 'a'
+    h[4.3] = 'b'
+
+    assert_equal [1.3, 'a' ], h.first
   end
 
   if RUBY_VERSION >= '1.9.0'


### PR DESCRIPTION
Keys must be Comparable (defines the <=> method).

I had to update the test to not try to use a `Symbol` as a key because it cannot be compared.
