### PR TITLE
Allow #values to be called on empty trees

### DIFF
--- a/lib/avl_tree.rb
+++ b/lib/avl_tree.rb
@@ -17,6 +17,10 @@ class AVLTree
         nil
       end
 
+      def values
+        []
+      end
+
       def size
         0
       end

--- a/lib/red_black_tree.rb
+++ b/lib/red_black_tree.rb
@@ -394,6 +394,10 @@ class RedBlackTree
         nil
       end
 
+      def values
+        []
+      end
+
       def size
         0
       end

--- a/test/test_avl_tree.rb
+++ b/test/test_avl_tree.rb
@@ -432,6 +432,12 @@ class TestAVLTree < Test::Unit::TestCase
     assert_equal [1.3, 'a' ], h.first
   end
 
+  def test_values_for_empty_tree
+    h = AVLTree.new
+
+    assert_equal [], h.values
+  end
+
   if RUBY_VERSION >= '1.9.0'
     # In contrast to RadixTree, AVLTree just uses String#<=> as-is
     def test_encoding

--- a/test/test_red_black_tree.rb
+++ b/test/test_red_black_tree.rb
@@ -582,6 +582,12 @@ class TestRedBlackTree < Test::Unit::TestCase
     assert_equal [1.3, 'a' ], h.first
   end
 
+  def test_values_for_empty_tree
+    h = RedBlackTree.new
+
+    assert_equal [], h.values
+  end
+
   if RUBY_VERSION >= '1.9.0'
     # In contrast to RadixTree, RedBlackTree just uses String#<=> as-is
     def test_encoding


### PR DESCRIPTION
We ran into an issue where calling `values()` on an empty tree throws an exception. You can see more details here: https://github.com/eric/metriks/issues/6
