### PR TITLE
Add missing runtime dependency on atomic to gemspec

### DIFF
--- a/avl_tree.gemspec
+++ b/avl_tree.gemspec
@@ -10,4 +10,5 @@ Gem::Specification.new { |s|
   s.summary = 'AVL tree, Red black tree and Lock-free Red black tree in Ruby'
   s.files = Dir.glob('{lib,bench,test}/**/*') + ['README.md']
   s.require_path = 'lib'
+  s.add_runtime_dependency "atomic", "~> 1.1"
 }


### PR DESCRIPTION
Avl_tree's gemspec is missing a runtime dependency on atomic gem, so when installed via bundler, a LoadError is raised on require 'red_black_tree':

```
 irb(main):001:0> require 'red_black_tree'
 LoadError: cannot load such file -- atomic
```

This patch adds the missing dependency.
