### PR TITLE
Fix raise on check_height for empty RB tree

### DIFF
--- a/lib/red_black_tree.rb
+++ b/lib/red_black_tree.rb
@@ -142,8 +142,8 @@ class RedBlackTree
 
     # for debugging
     def check_height
-      lh = @left.empty? ? 0 : @left.check_height
-      rh = @right.empty? ? 0 : @right.check_height
+      lh = @left.nil?  || @left.empty? ? 0 : @left.check_height
+      rh = @right.nil? || @right.empty? ? 0 : @right.check_height
       if red?
         if @left.red? or @right.red?
           puts dump_tree(STDERR)

--- a/test/test_red_black_tree.rb
+++ b/test/test_red_black_tree.rb
@@ -608,6 +608,12 @@ module RedBlackTreeTest
     assert_equal [], h.values
   end
 
+  def test_check_height_on_empty_tree
+    h = create_test_target
+
+    assert_nothing_raised { h.root.check_height }
+  end
+
   if RUBY_VERSION >= '1.9.0'
     # In contrast to RadixTree, RedBlackTree just uses String#<=> as-is
     def test_encoding


### PR DESCRIPTION
An empty RB tree has a single EmptyNode as its root. As EmptyNode returns nil when calling right or left and thus, check_height on empty tree fails.

This patch modifies check_height so it returns 0 height even if children are nil and adds a test for this case.
