### PR TITLE
Change use of Enumerator.new to #enum_for

### DIFF
--- a/lib/avl_tree.rb
+++ b/lib/avl_tree.rb
@@ -323,7 +323,7 @@ class AVLTree
       @root.each(&block)
       self
     else
-      Enumerator.new(@root)
+      @root.enum_for(:each)
     end
   end
   alias each_pair each
@@ -335,7 +335,7 @@ class AVLTree
       end
       self
     else
-      Enumerator.new(@root, :each_key)
+      @root.enum_for(:each_key)
     end
   end
 
@@ -346,7 +346,7 @@ class AVLTree
       end
       self
     else
-      Enumerator.new(@root, :each_value)
+      @root.enum_for(:each_value)
     end
   end
 

--- a/lib/red_black_tree.rb
+++ b/lib/red_black_tree.rb
@@ -457,7 +457,7 @@ class RedBlackTree
       root.each(&block)
       self
     else
-      Enumerator.new(root)
+      root.enum_for(:each)
     end
   end
   alias each_pair each
@@ -469,7 +469,7 @@ class RedBlackTree
       end
       self
     else
-      Enumerator.new(root, :each_key)
+      root.enum_for(:each_key)
     end
   end
 
@@ -480,7 +480,7 @@ class RedBlackTree
       end
       self
     else
-      Enumerator.new(root, :each_value)
+      root.enum_for(:each_value)
     end
   end
 


### PR DESCRIPTION
`Enumerator.new` throws warning under 2.2. Changed to use the
underlying root object and `#enum_for`.
